### PR TITLE
🔒 [security] Fix insecure output file creation

### DIFF
--- a/promptpacker.go
+++ b/promptpacker.go
@@ -1057,7 +1057,7 @@ func startProcessing(cfg config, entries []walkEntry, progressChan chan<- tea.Ms
 
 func startWriting(cfg config, entries []walkEntry, processedContent map[string]fileResult, progressChan chan<- tea.Msg) tea.Cmd {
 	return func() tea.Msg {
-		outFile, err := os.Create(cfg.outputFile)
+		outFile, err := os.OpenFile(cfg.outputFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return writeCompleteMsg{err: err}
 		}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is insecure output file creation in `promptpacker.go`.

⚠️ **Risk:** The application previously used `os.Create` to generate the output Markdown file. `os.Create` uses default permissions (0666 modified by umask), which typically makes the file world-readable. Since this tool is used to package codebases for LLMs, the output files often contain sensitive source code or data that should not be accessible to other users on the system.

🛡️ **Solution:** Replaced `os.Create(cfg.outputFile)` with `os.OpenFile(cfg.outputFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)`. This explicitly sets the file permissions to `0600` (read/write for the owner only), following security best practices for handling potentially sensitive data.

---
*PR created automatically by Jules for task [5513964869424470092](https://jules.google.com/task/5513964869424470092) started by @ImmaZoni*