### PR TITLE
Fix path normalization for prefix matching

### DIFF
--- a/promptpacker.go
+++ b/promptpacker.go
@@ -2148,7 +2148,10 @@ func (m fileSelectorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // dirHasSelectedDescendants returns true if any selected path is inside the given directory
 func (m fileSelectorModel) dirHasSelectedDescendants(dirPath string) bool {
 	// Normalize to forward slashes for consistent prefix matching
-	dirSlash := filepath.ToSlash(dirPath) + "/"
+	dirSlash := filepath.ToSlash(dirPath)
+	if !strings.HasSuffix(dirSlash, "/") {
+		dirSlash += "/"
+	}
 	for selPath := range m.selected {
 		if strings.HasPrefix(filepath.ToSlash(selPath), dirSlash) {
 			return true
@@ -2161,7 +2164,10 @@ func (m fileSelectorModel) dirHasSelectedDescendants(dirPath string) bool {
 func (m fileSelectorModel) isSelectedByParent(itemPath string) bool {
 	itemSlash := filepath.ToSlash(itemPath)
 	for selPath := range m.selected {
-		selSlash := filepath.ToSlash(selPath) + "/"
+		selSlash := filepath.ToSlash(selPath)
+		if !strings.HasSuffix(selSlash, "/") {
+			selSlash += "/"
+		}
 		if strings.HasPrefix(itemSlash, selSlash) {
 			return true
 		}


### PR DESCRIPTION
Fixed the path normalization logic in `promptpacker.go` to handle Windows edge cases where unconditional appending of a forward slash would create double slashes (e.g., `C://`). This was preventing correct prefix matching for selected files and directories. The fix now checks if a trailing slash already exists before appending one.

---
*PR created automatically by Jules for task [1688443711866212680](https://jules.google.com/task/1688443711866212680) started by @ImmaZoni*