### PR TITLE
🧹 Simplify unnecessary array usage for variable 'first'

### DIFF
--- a/promptpacker.go
+++ b/promptpacker.go
@@ -1454,11 +1454,7 @@ func yamlToJSON(yaml string) string {
 	lines := strings.Split(yaml, "\n")
 	var buf strings.Builder
 	buf.WriteString("{")
-	type stackEntry struct{ key string }
-	indent := 0
-	first := [3]bool{true, true, true}
-	_ = indent
-	_ = stackEntry{}
+	first := true
 	// Simple line-by-line parsing
 	topSection := ""
 	subSection := ""
@@ -1520,10 +1516,10 @@ func yamlToJSON(yaml string) string {
 				kv := strings.SplitN(trimmed, ":", 2)
 				if len(kv) == 2 {
 					if subSection == "" {
-						if !first[0] {
+						if !first {
 							buf.WriteString(",")
 						}
-						first[0] = false
+						first = false
 					} else {
 						if !firstItem {
 							buf.WriteString(",")

--- a/promptpacker_test.go
+++ b/promptpacker_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestYamlToJSON(t *testing.T) {
+	testYAML := `
+defaults:
+  mode: auto
+  structure-only: true
+profiles:
+  llm:
+    mode: auto
+    exclude-ext: log,tmp
+  structure:
+    structure-only: true
+    max-depth: 3
+`
+	expected := `{"defaults":{"mode":"auto","structure-only":true},"profiles":{"llm":{"mode":"auto","exclude-ext":"log,tmp"},"structure":{"structure-only":true,"max-depth":3}}}`
+	result := yamlToJSON(testYAML)
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}


### PR DESCRIPTION
Simplified the 'first' variable in 'yamlToJSON' from a [3]bool array to a single boolean.
Removed unused 'indent' and 'stackEntry' variables.
Added a unit test 'promptpacker_test.go' to verify the 'yamlToJSON' function logic.
Verified the logic using a standalone script (since full project build failed due to environment/network constraints).

---
*PR created automatically by Jules for task [8341430350301744076](https://jules.google.com/task/8341430350301744076) started by @ImmaZoni*