### PR TITLE
🔒 Fix unescaped XML output vulnerability

### DIFF
--- a/promptpacker.go
+++ b/promptpacker.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"flag"
 	"fmt"
 	"io"
@@ -1207,7 +1208,9 @@ func processFileContent(entry walkEntry, cfg config) (string, error) {
 	var buf bytes.Buffer
 
 	if cfg.format == "xml" {
-		header := fmt.Sprintf("<file name=\"%s\">\n", entry.relPath)
+		var escapedName bytes.Buffer
+		xml.EscapeText(&escapedName, []byte(entry.relPath))
+		header := fmt.Sprintf("<file name=\"%s\">\n", escapedName.String())
 		buf.WriteString(header)
 	} else {
 		header := fmt.Sprintf("## %s\n\n", entry.relPath)
@@ -1239,7 +1242,11 @@ func processFileContent(entry walkEntry, cfg config) (string, error) {
 					contentStr = re.ReplaceAllString(contentStr, "[REDACTED_BY_PROMPTPACKER]")
 				}
 			}
-			buf.WriteString(contentStr)
+			if cfg.format == "xml" {
+				xml.EscapeText(&buf, []byte(contentStr))
+			} else {
+				buf.WriteString(contentStr)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a security vulnerability where XML output was generated without proper escaping of file paths and contents.

### 🎯 What:
Fixed an XML injection vulnerability in `processFileContent`.

### ⚠️ Risk:
Maliciously crafted file names or file contents could break the XML structure or lead to XML injection attacks when the output format is set to XML.

### 🛡️ Solution:
Used `encoding/xml.EscapeText` to properly escape both the `name` attribute in the `<file>` tag and the file content itself. This ensures all XML-sensitive characters (e.g., `<`, `>`, `&`, `"`, `'`) are correctly sanitized.

---
*PR created automatically by Jules for task [7436778266951278958](https://jules.google.com/task/7436778266951278958) started by @ImmaZoni*