### PR TITLE
🧹 Remove unused 'stackEntry' and 'indent' variables

### DIFF
--- a/promptpacker.go
+++ b/promptpacker.go
@@ -1587,11 +1587,7 @@ func yamlToJSON(yaml string) string {
 	lines := strings.Split(yaml, "\n")
 	var buf strings.Builder
 	buf.WriteString("{")
-	type stackEntry struct{ key string }
-	indent := 0
 	first := [3]bool{true, true, true}
-	_ = indent
-	_ = stackEntry{}
 	// Simple line-by-line parsing
 	topSection := ""
 	subSection := ""


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed unused local struct `stackEntry` and variable `indent` from the `yamlToJSON` function in `promptpacker.go`.
- Removed their corresponding blank identifier assignments (`_ = indent`, `_ = stackEntry{}`).

💡 **Why:** How this improves maintainability
- Eliminates dead code that serves no purpose.
- Reduces clutter and potential confusion for future maintainers.

✅ **Verification:** How you confirmed the change is safe
- Verified the logic of `yamlToJSON` with a standalone script to ensure it still correctly parses sample YAML configurations into JSON.
- Confirmed that the variables were truly unused (they were already suppressed with `_`).

✨ **Result:** The improvement achieved
- Cleaner, more readable code in `yamlToJSON`.

---
*PR created automatically by Jules for task [10996836939278298689](https://jules.google.com/task/10996836939278298689) started by @ImmaZoni*