### PR TITLE
🧪 Add tests for formatSize function

### DIFF
--- a/promptpacker_test.go
+++ b/promptpacker_test.go
@@ -5,6 +5,32 @@ import (
 	"testing"
 )
 
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{500, "500 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{1536 * 1024, "1.5 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+		{1024 * 1024 * 1024 * 1024, "1.0 TB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatSize(tt.input)
+			if result != tt.expected {
+				t.Errorf("formatSize(%d) = %q; want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestParseSize(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds comprehensive table-driven tests for the `formatSize` utility function, which converts byte sizes into human-readable strings.

📊 **Coverage:** What scenarios are now tested
The new `TestFormatSize` function covers:
- Boundary cases: 0 bytes, 1023 bytes (just under 1 KB)
- Exactly boundary thresholds: 1024 bytes (1 KB), 1 MB, 1 GB, 1 TB
- Fractional outputs: 1.5 KB, 1.5 MB

✨ **Result:** The improvement in test coverage
`formatSize` is now fully tested against various boundaries, guaranteeing that byte formatting works exactly as expected without regressions.

---
*PR created automatically by Jules for task [10025685241650378049](https://jules.google.com/task/10025685241650378049) started by @ImmaZoni*