### PR TITLE
🔒 fix: escape XML output to prevent injection

### DIFF
--- a/promptpacker.go
+++ b/promptpacker.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"flag"
 	"fmt"
 	"io"
@@ -1207,8 +1208,9 @@ func processFileContent(entry walkEntry, cfg config) (string, error) {
 	var buf bytes.Buffer
 
 	if cfg.format == "xml" {
-		header := fmt.Sprintf("<file name=\"%s\">\n", entry.relPath)
-		buf.WriteString(header)
+		buf.WriteString("<file name=\"")
+		xml.EscapeText(&buf, []byte(entry.relPath))
+		buf.WriteString("\">\n")
 	} else {
 		header := fmt.Sprintf("## %s\n\n", entry.relPath)
 		buf.WriteString(header)
@@ -1239,7 +1241,11 @@ func processFileContent(entry walkEntry, cfg config) (string, error) {
 					contentStr = re.ReplaceAllString(contentStr, "[REDACTED_BY_PROMPTPACKER]")
 				}
 			}
-			buf.WriteString(contentStr)
+			if cfg.format == "xml" {
+				xml.EscapeText(&buf, []byte(contentStr))
+			} else {
+				buf.WriteString(contentStr)
+			}
 		}
 	}
 


### PR DESCRIPTION
🎯 **What:** Fixed an XML injection vulnerability in the output formatter.
⚠️ **Risk:** When `promptpacker` generated XML output (`--format=xml`), file contents and file paths were written to the output stream without any escaping or sanitization. If a file contained raw XML characters (such as `<script>`, `<file>`, or `&`), they were interpreted as valid XML structures, breaking the XML layout and potentially injecting malicious tags into the output, leading to data corruption or exploitation by downstream parsers.
🛡️ **Solution:** Added `"encoding/xml"` to imports and updated `processFileContent` to securely escape both the file path (in the header `<file name="...">`) and the file content block using `xml.EscapeText`, neutralizing raw `<`, `>`, `&`, `"`, and `'` characters.

---
*PR created automatically by Jules for task [11160361852646176443](https://jules.google.com/task/11160361852646176443) started by @ImmaZoni*